### PR TITLE
Allows angular 1.5 as dependency, add instruction in readme to display numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ bower install angular-keypad --save
 
 ## Dependencies
 
-- Angular.js (~1.4.0)
+- Angular.js (>=1.4.0)
 
 
 ## Usage
@@ -48,6 +48,9 @@ Use the directive anywhere in your HTML. The keypad will expand to fill the widt
 while maintaining the aspect ratio of the keypad buttons.
 
 ```html
+<!-- Add the input where to put display numbers: -->
+<input type="text" data-ng-model="vm.numbers">
+
 <!-- Define the keypad: -->
 <bc-keypad
   bc-number-model="vm.numbers"

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "numbers"
   ],
   "dependencies": {
-    "angular": "~1.4.0"
+    "angular": ">=1.4.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
As it works under angular 1.5, it should allows a bigger version range to avoid incompatibilities in bower install.